### PR TITLE
patch queue to never miss a task

### DIFF
--- a/lib/temporal.js
+++ b/lib/temporal.js
@@ -153,6 +153,8 @@ exportable.queue = function( tasks ) {
 //    https://dl.dropbox.com/u/3531958/empirejs/index.html
 //
 
+var previousTick = Date.now();
+
 setImmediate(function tick() {
   var now, entry, entries, temporald;
 
@@ -161,6 +163,13 @@ setImmediate(function tick() {
 
   // Derive entries stack from queue
   entries = queue[ now ] || [];
+  for (var i = previousTick; i <= now; i++) {
+    entries = queue[ i ] || [];
+    if (entries.length) {
+      break;
+    }  
+  }
+  previousTick = i;
 
   if ( entries.length ) {
 


### PR DESCRIPTION
Keep "now" value from previous tick. In next tick, search in queue tab if there is a callback to execute between previous tick "now" and next tick "now". 
